### PR TITLE
Rename cmake presets, make Qt6 the default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
           - macos-latest
         qt:
           - version: 6.5.0
-            preset: dev6
+            preset: dev
           - version: 6.7.1
-            preset: dev6
+            preset: dev
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js 18.x

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /test/qt_test/build-dev/
+/test/qt_test/build-dev5/
 /test/qt_test/compile_commands.json
 /test/qt_test/.cache
 *.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /node_modules
 /test/qt_test/build-dev/
-/test/qt_test/build-dev5/
 /test/qt_test/compile_commands.json
 /test/qt_test/.cache
 *.tgz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,6 @@ cmake --build test/qt_test/build-dev/
 node out/test.js
 ```
 
-Use preset `dev5` for Qt 5 builds.
-
 ### Run the example
 ```bash
 node out/example.js test/qt_test/build-dev
@@ -49,7 +47,7 @@ When a Qt test runs, the library invokes the executable with `-o <name>.tap,tap 
 
 ### Qt test fixtures (`test/qt_test/`)
 
-C++ test executables (`test1`, `test2`, `test3`, `non_qttest`) are pre-built into `test/qt_test/build-dev/`. The `non_qttest` executable exercises the non-QtTest filtering path. `CMakePresets.json` defines `dev` (Qt 6) and `dev5` (Qt 5) presets.
+C++ test executables (`test1`, `test2`, `test3`, `non_qttest`) are pre-built into `test/qt_test/build-dev/`. The `non_qttest` executable exercises the non-QtTest filtering path. `CMakePresets.json` defines the `dev` preset.
 
 ## Commit conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,11 @@ cmake --build test/qt_test/build-dev/
 node out/test.js
 ```
 
-Use preset `dev6` for Qt 6 builds.
+Use preset `dev5` for Qt 5 builds.
 
 ### Run the example
 ```bash
-node out/example.js test/qt_test/build-dev6
+node out/example.js test/qt_test/build-dev
 ```
 
 ## Architecture
@@ -49,7 +49,7 @@ When a Qt test runs, the library invokes the executable with `-o <name>.tap,tap 
 
 ### Qt test fixtures (`test/qt_test/`)
 
-C++ test executables (`test1`, `test2`, `test3`, `non_qttest`) are pre-built into `test/qt_test/build-dev/`. The `non_qttest` executable exercises the non-QtTest filtering path. `CMakePresets.json` defines `dev` (Qt 5) and `dev6` (Qt 6) presets.
+C++ test executables (`test1`, `test2`, `test3`, `non_qttest`) are pre-built into `test/qt_test/build-dev/`. The `non_qttest` executable exercises the non-QtTest filtering path. `CMakePresets.json` defines `dev` (Qt 6) and `dev5` (Qt 5) presets.
 
 ## Commit conventions
 

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,3 @@
 cmake --preset=dev -S test/qt_test && \
 cmake --build test/qt_test/build-dev && \
-tsc && node out/test.js && \
-rm -rf test/qt_test/build-dev && \
-cmake --preset=dev5 -S test/qt_test && \
-cmake --build test/qt_test/build-dev5 && \
 tsc && node out/test.js

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,6 @@ cmake --preset=dev -S test/qt_test && \
 cmake --build test/qt_test/build-dev && \
 tsc && node out/test.js && \
 rm -rf test/qt_test/build-dev && \
-cmake --preset=dev6 -S test/qt_test && \
-cmake --build test/qt_test/build-dev && \
+cmake --preset=dev5 -S test/qt_test && \
+cmake --build test/qt_test/build-dev5 && \
 tsc && node out/test.js

--- a/test/qt_test/CMakePresets.json
+++ b/test/qt_test/CMakePresets.json
@@ -11,14 +11,6 @@
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "USE_QT6": "ON"
       }
-    },
-    {
-      "name": "dev5",
-      "displayName": "dev5",
-      "inherits": "dev",
-      "cacheVariables": {
-        "USE_QT6": "OFF"
-      }
     }
   ]
 }

--- a/test/qt_test/CMakePresets.json
+++ b/test/qt_test/CMakePresets.json
@@ -8,15 +8,16 @@
       "binaryDir": "${sourceDir}/build-${presetName}",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "USE_QT6": "ON"
       }
     },
     {
-      "name": "dev6",
-      "displayName": "dev6",
+      "name": "dev5",
+      "displayName": "dev5",
       "inherits": "dev",
       "cacheVariables": {
-        "USE_QT6": "ON"
+        "USE_QT6": "OFF"
       }
     }
   ]


### PR DESCRIPTION
Closes #6

- Renamed `dev` (Qt5) → removed (Qt5 no longer supported)
- Renamed `dev6` (Qt6) → `dev` (now the default)
- Updated CI, test.sh, .gitignore, and docs accordingly