### PR TITLE
Bump TypeScript target to ES2022 and add engines field

### DIFF
--- a/out/cmake.js
+++ b/out/cmake.js
@@ -2,15 +2,6 @@
 // SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 // Author: Sergio Martins <sergio.martins@kdab.com>
 // SPDX-License-Identifier: MIT
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -25,6 +16,8 @@ const qttest_1 = require("./qttest");
  * Contains methods to discover Qt Tests via CMake
  */
 class CMakeTests {
+    // The build dir where we'll run
+    buildDirPath;
     constructor(buildDirPath) {
         this.buildDirPath = buildDirPath;
     }
@@ -33,39 +26,37 @@ class CMakeTests {
      *
      * @returns a promise with the list of tests
      */
-    tests() {
-        return __awaiter(this, void 0, void 0, function* () {
-            // TODO: Check if folder exists
-            if (this.buildDirPath.length == 0) {
-                console.error("Could not find out cmake build dir");
-                return undefined;
-            }
-            return new Promise((resolve, reject) => {
-                (0, qttest_1.logMessage)("Running ctest --show-only=json-v1 with cwd=" + this.buildDirPath);
-                const child = (0, child_process_1.spawn)("ctest", ["--show-only=json-v1"], {
-                    cwd: this.buildDirPath,
-                });
-                let output = "";
-                child.stdout.on("data", (chunk) => {
-                    output += chunk.toString();
-                });
-                child.on("close", (code) => {
-                    if (code === 0) {
-                        if (output.length == 0) {
-                            console.error("ctestJsonToList: Empty json output. Command was ctest --show-only=json-v1 , in " +
-                                this.buildDirPath);
-                            reject(new Error("Failed to get ctest JSON output"));
-                        }
-                        else {
-                            resolve(this.ctestJsonToList(output));
-                        }
+    async tests() {
+        // TODO: Check if folder exists
+        if (this.buildDirPath.length == 0) {
+            console.error("Could not find out cmake build dir");
+            return undefined;
+        }
+        return new Promise((resolve, reject) => {
+            (0, qttest_1.logMessage)("Running ctest --show-only=json-v1 with cwd=" + this.buildDirPath);
+            const child = (0, child_process_1.spawn)("ctest", ["--show-only=json-v1"], {
+                cwd: this.buildDirPath,
+            });
+            let output = "";
+            child.stdout.on("data", (chunk) => {
+                output += chunk.toString();
+            });
+            child.on("close", (code) => {
+                if (code === 0) {
+                    if (output.length == 0) {
+                        console.error("ctestJsonToList: Empty json output. Command was ctest --show-only=json-v1 , in " +
+                            this.buildDirPath);
+                        reject(new Error("Failed to get ctest JSON output"));
                     }
                     else {
-                        reject(new Error("Failed to run ctest"));
+                        resolve(this.ctestJsonToList(output));
                     }
-                });
-                return undefined;
+                }
+                else {
+                    reject(new Error("Failed to run ctest"));
+                }
             });
+            return undefined;
         });
     }
     ctestJsonToList(json) {
@@ -209,10 +200,8 @@ class CMakeTests {
 exports.CMakeTests = CMakeTests;
 /// Represents an inividual CTest test
 class CMakeTest {
-    constructor() {
-        this.command = [];
-        this.cwd = "";
-    }
+    command = [];
+    cwd = "";
     id() {
         return this.command.join(",");
     }

--- a/out/example.js
+++ b/out/example.js
@@ -2,77 +2,66 @@
 // SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 // Author: Sergio Martins <sergio.martins@kdab.com>
 // SPDX-License-Identifier: MIT
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const qttest_1 = require("./qttest");
 const fs_1 = __importDefault(require("fs"));
-function example() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const args = process.argv.slice(2);
-        if (args.length != 1) {
-            console.error("ERROR: Expected a single argument with the build-dir with cmake tests!");
-            process.exit(2);
-        }
-        let buildDirPath = args[0];
-        if (!fs_1.default.existsSync(buildDirPath)) {
-            console.error('Directory does not exist!');
-            process.exit(1);
-        }
-        let qt = new qttest_1.QtTests();
-        qt.setLogFunction((message) => {
-            console.log(message);
-        });
-        // Gather all tests that would be executed by CTest:
-        yield qt.discoverViaCMake(buildDirPath);
-        // Filter-out the ones that don't link to QtTest (doctests and such)
-        yield qt.removeNonLinking();
-        // Example of filtering out by regexp:
-        qt.removeMatching(/(tst_view|tst_window)/);
-        // Uncomment to see example of filtering out by regexp (inverted):
-        // qt.maintainMatching(/(tst_docks|tst_qtwidgets|tst_multisplitter)/);
-        qt.dumpExecutablePaths();
-        yield qt.dumpTestSlots();
-        console.log("\nRunning tests...");
-        for (var executable of qt.qtTestExecutables) {
-            yield executable.runTest();
-            if (executable.lastExitCode === 0)
-                console.log("    PASS: " + executable.filename);
-            else
-                console.log("    FAIL: " + executable.filename + "; code=" + executable.lastExitCode);
-            for (let slot of executable.slots) {
-                if (slot.lastTestFailure) {
-                    console.log("        failed slot=" + slot.name + "; path=" + slot.lastTestFailure.filePath + "; line=" + slot.lastTestFailure.lineNumber);
-                }
-                else {
-                    console.log("        pass: " + slot.name);
-                }
+async function example() {
+    const args = process.argv.slice(2);
+    if (args.length != 1) {
+        console.error("ERROR: Expected a single argument with the build-dir with cmake tests!");
+        process.exit(2);
+    }
+    let buildDirPath = args[0];
+    if (!fs_1.default.existsSync(buildDirPath)) {
+        console.error('Directory does not exist!');
+        process.exit(1);
+    }
+    let qt = new qttest_1.QtTests();
+    qt.setLogFunction((message) => {
+        console.log(message);
+    });
+    // Gather all tests that would be executed by CTest:
+    await qt.discoverViaCMake(buildDirPath);
+    // Filter-out the ones that don't link to QtTest (doctests and such)
+    await qt.removeNonLinking();
+    // Example of filtering out by regexp:
+    qt.removeMatching(/(tst_view|tst_window)/);
+    // Uncomment to see example of filtering out by regexp (inverted):
+    // qt.maintainMatching(/(tst_docks|tst_qtwidgets|tst_multisplitter)/);
+    qt.dumpExecutablePaths();
+    await qt.dumpTestSlots();
+    console.log("\nRunning tests...");
+    for (var executable of qt.qtTestExecutables) {
+        await executable.runTest();
+        if (executable.lastExitCode === 0)
+            console.log("    PASS: " + executable.filename);
+        else
+            console.log("    FAIL: " + executable.filename + "; code=" + executable.lastExitCode);
+        for (let slot of executable.slots) {
+            if (slot.lastTestFailure) {
+                console.log("        failed slot=" + slot.name + "; path=" + slot.lastTestFailure.filePath + "; line=" + slot.lastTestFailure.lineNumber);
+            }
+            else {
+                console.log("        pass: " + slot.name);
             }
         }
-        // Also run individual slots, just for example purposes:
-        console.log("\nRunning single tests...");
-        let slot = qt.qtTestExecutables[1].slots[0];
-        yield slot.runTest();
-        if (slot.lastTestFailure)
-            console.log("    FAIL:" + JSON.stringify(slot.lastTestFailure));
-        else
-            console.log("    PASS:");
-        let slot2 = qt.qtTestExecutables[1].slots[2];
-        yield slot2.runTest();
-        if (slot2.lastTestFailure)
-            console.log("    FAIL:" + JSON.stringify(slot2.lastTestFailure));
-        else
-            console.log("    PASS");
-    });
+    }
+    // Also run individual slots, just for example purposes:
+    console.log("\nRunning single tests...");
+    let slot = qt.qtTestExecutables[1].slots[0];
+    await slot.runTest();
+    if (slot.lastTestFailure)
+        console.log("    FAIL:" + JSON.stringify(slot.lastTestFailure));
+    else
+        console.log("    PASS:");
+    let slot2 = qt.qtTestExecutables[1].slots[2];
+    await slot2.runTest();
+    if (slot2.lastTestFailure)
+        console.log("    FAIL:" + JSON.stringify(slot2.lastTestFailure));
+    else
+        console.log("    PASS");
 }
 example();

--- a/out/qttest.js
+++ b/out/qttest.js
@@ -25,15 +25,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -56,15 +47,19 @@ exports.logMessage = logMessage;
  * Supports listing the individual test slots
  */
 class QtTest {
+    filename;
+    buildDirPath;
+    /// If true, will print more verbose output
+    verbose = false;
+    /// Allows vscode extensions to associate with a test item
+    vscodeTestItem;
+    /// The list of individual runnable test slots
+    slots = null;
+    /// Set after running
+    lastExitCode = 0;
+    /// Allows the caller to receive the output of the test process
+    outputFunc = undefined;
     constructor(filename, buildDirPath) {
-        /// If true, will print more verbose output
-        this.verbose = false;
-        /// The list of individual runnable test slots
-        this.slots = null;
-        /// Set after running
-        this.lastExitCode = 0;
-        /// Allows the caller to receive the output of the test process
-        this.outputFunc = undefined;
         this.filename = filename;
         this.buildDirPath = buildDirPath;
     }
@@ -93,48 +88,46 @@ class QtTest {
     /**
      * Calls "./yourqttest -functions" and stores the results in the slots property.
      */
-    parseAvailableSlots() {
-        return __awaiter(this, void 0, void 0, function* () {
-            let slotNames = [];
-            let output = "";
-            let err = "";
-            yield new Promise((resolve, reject) => {
-                if (!fs.existsSync(this.filename)) {
-                    reject(new Error("qttest: File doesn't exit: " + this.filename));
-                    return;
-                }
-                const child = (0, child_process_1.spawn)(this.filename, ["-functions"], {
-                    cwd: this.buildDirPath,
-                });
-                child.stdout.on("data", (chunk) => {
-                    output += chunk.toString();
-                });
-                child.stderr.on("data", (chunk) => {
-                    err += chunk.toString();
-                });
-                child.on("exit", (code) => {
-                    if (code === 0) {
-                        slotNames = slotNames.concat(output.split("\n"));
-                        slotNames = slotNames.map((entry) => entry.trim().replace("()", ""));
-                        slotNames = slotNames.filter((entry) => entry.length > 0);
-                        if (slotNames.length > 0) {
-                            this.slots = [];
-                            for (var slotName of slotNames) {
-                                var slot = new QtTestSlot(slotName, this);
-                                this.slots.push(slot);
-                            }
+    async parseAvailableSlots() {
+        let slotNames = [];
+        let output = "";
+        let err = "";
+        await new Promise((resolve, reject) => {
+            if (!fs.existsSync(this.filename)) {
+                reject(new Error("qttest: File doesn't exit: " + this.filename));
+                return;
+            }
+            const child = (0, child_process_1.spawn)(this.filename, ["-functions"], {
+                cwd: this.buildDirPath,
+            });
+            child.stdout.on("data", (chunk) => {
+                output += chunk.toString();
+            });
+            child.stderr.on("data", (chunk) => {
+                err += chunk.toString();
+            });
+            child.on("exit", (code) => {
+                if (code === 0) {
+                    slotNames = slotNames.concat(output.split("\n"));
+                    slotNames = slotNames.map((entry) => entry.trim().replace("()", ""));
+                    slotNames = slotNames.filter((entry) => entry.length > 0);
+                    if (slotNames.length > 0) {
+                        this.slots = [];
+                        for (var slotName of slotNames) {
+                            var slot = new QtTestSlot(slotName, this);
+                            this.slots.push(slot);
                         }
-                        resolve(slotNames);
                     }
-                    else {
-                        reject(new Error("qttest: Failed to run -functions, stdout=" +
-                            output +
-                            "; stderr=" +
-                            err +
-                            "; code=" +
-                            code));
-                    }
-                });
+                    resolve(slotNames);
+                }
+                else {
+                    reject(new Error("qttest: Failed to run -functions, stdout=" +
+                        output +
+                        "; stderr=" +
+                        err +
+                        "; code=" +
+                        code));
+                }
             });
         });
     }
@@ -178,27 +171,25 @@ class QtTest {
     }
     /// Returns whether this test is a QtTest by running it with -help and checking if the help text looks familiar
     /// Note that if this is not a QtTest it might not run help and instead execute the test itself
-    isQtTestViaHelp() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return yield new Promise((resolve, reject) => {
-                const child = (0, child_process_1.spawn)(this.filename, ["-help"]);
-                let output = "";
-                let result = false;
-                child.stdout.on("data", (chunk) => {
-                    if (!result) {
-                        if (chunk.toString().includes("[testfunction[:testdata]]")) {
-                            result = true;
-                        }
+    async isQtTestViaHelp() {
+        return await new Promise((resolve, reject) => {
+            const child = (0, child_process_1.spawn)(this.filename, ["-help"]);
+            let output = "";
+            let result = false;
+            child.stdout.on("data", (chunk) => {
+                if (!result) {
+                    if (chunk.toString().includes("[testfunction[:testdata]]")) {
+                        result = true;
                     }
-                });
-                child.on("exit", (code) => {
-                    if (code === 0) {
-                        resolve(result);
-                    }
-                    else {
-                        resolve(false);
-                    }
-                });
+                }
+            });
+            child.on("exit", (code) => {
+                if (code === 0) {
+                    resolve(result);
+                }
+                else {
+                    resolve(false);
+                }
             });
         });
     }
@@ -212,64 +203,62 @@ class QtTest {
         return undefined;
     }
     /// Runs this test
-    runTest(slot_1) {
-        return __awaiter(this, arguments, void 0, function* (slot, cwd = "") {
-            let args = [];
-            if (slot) {
-                // Runs a single Qt test instead
-                args = args.concat(slot.name);
+    async runTest(slot, cwd = "") {
+        let args = [];
+        if (slot) {
+            // Runs a single Qt test instead
+            args = args.concat(slot.name);
+        }
+        else {
+            this.clearSubTestStates();
+        }
+        // log to file and to stdout
+        args = args.concat("-o").concat(this.tapOutputFileName(slot) + ",tap");
+        args = args.concat("-o").concat(this.txtOutputFileName(slot) + ",txt");
+        args = args.concat("-o").concat("-,txt");
+        return await new Promise((resolve, reject) => {
+            let cwdDir = cwd.length > 0 ? cwd : this.buildDirPath;
+            logMessage("Running " +
+                this.filename +
+                " " +
+                args.join(" ") +
+                " with cwd=" +
+                cwdDir);
+            const child = (0, child_process_1.spawn)(this.filename, args, { cwd: cwdDir });
+            if (this.outputFunc) {
+                // Callers wants the process output:
+                child.stdout.on("data", (chunk) => {
+                    if (this.outputFunc)
+                        this.outputFunc(chunk.toString());
+                });
+                child.stderr.on("data", (chunk) => {
+                    if (this.outputFunc)
+                        this.outputFunc(chunk.toString());
+                });
             }
-            else {
-                this.clearSubTestStates();
-            }
-            // log to file and to stdout
-            args = args.concat("-o").concat(this.tapOutputFileName(slot) + ",tap");
-            args = args.concat("-o").concat(this.txtOutputFileName(slot) + ",txt");
-            args = args.concat("-o").concat("-,txt");
-            return yield new Promise((resolve, reject) => {
-                let cwdDir = cwd.length > 0 ? cwd : this.buildDirPath;
-                logMessage("Running " +
-                    this.filename +
-                    " " +
-                    args.join(" ") +
-                    " with cwd=" +
-                    cwdDir);
-                const child = (0, child_process_1.spawn)(this.filename, args, { cwd: cwdDir });
-                if (this.outputFunc) {
-                    // Callers wants the process output:
-                    child.stdout.on("data", (chunk) => {
-                        if (this.outputFunc)
-                            this.outputFunc(chunk.toString());
-                    });
-                    child.stderr.on("data", (chunk) => {
-                        if (this.outputFunc)
-                            this.outputFunc(chunk.toString());
-                    });
+            child.on("exit", async (code) => {
+                /// Can code even be null ?
+                if (code == undefined)
+                    code = -1;
+                if (!slot) {
+                    this.lastExitCode = code;
                 }
-                child.on("exit", (code) => __awaiter(this, void 0, void 0, function* () {
-                    /// Can code even be null ?
-                    if (code == undefined)
-                        code = -1;
-                    if (!slot) {
-                        this.lastExitCode = code;
+                if (this.slots && this.slots.length > 0) {
+                    /// When running a QtTest executable, let's check which sub-tests failed
+                    /// (So VSCode can show some error icon for each fail)
+                    try {
+                        await this.updateSubTestStates(cwdDir, slot);
                     }
-                    if (this.slots && this.slots.length > 0) {
-                        /// When running a QtTest executable, let's check which sub-tests failed
-                        /// (So VSCode can show some error icon for each fail)
-                        try {
-                            yield this.updateSubTestStates(cwdDir, slot);
-                        }
-                        catch (e) {
-                            logMessage("Failed to update sub-test states: " + e);
-                        }
+                    catch (e) {
+                        logMessage("Failed to update sub-test states: " + e);
                     }
-                    if (code === 0) {
-                        resolve(true);
-                    }
-                    else {
-                        resolve(false);
-                    }
-                }));
+                }
+                if (code === 0) {
+                    resolve(true);
+                }
+                else {
+                    resolve(false);
+                }
             });
         });
     }
@@ -293,76 +282,74 @@ class QtTest {
             }
         }
     }
-    updateSubTestStates(cwdDir, slot) {
-        return __awaiter(this, void 0, void 0, function* () {
-            let tapFileName = cwdDir + "/" + this.tapOutputFileName(slot);
-            var failures = yield new Promise((resolve, reject) => {
-                fs.readFile(tapFileName, "utf8", (error, data) => {
-                    if (error) {
-                        logMessage("ERROR: Failed to read log file");
-                        reject(error);
-                    }
-                    else {
-                        let failedResults = [];
-                        try {
-                            const tap_events = tap_parser_1.Parser.parse(data);
-                            for (let event of tap_events) {
-                                try {
-                                    if (event.length < 2)
-                                        continue;
-                                    if (event.at(0) != "assert")
-                                        continue;
-                                    var obj = event.at(1);
-                                    let pass = obj["ok"] === true;
-                                    let xfail = !pass && obj["todo"] !== false;
-                                    if (xfail) {
-                                        // This is a QEXPECT_FAIL test, all good.
-                                        // QtTest outputs it as "todo"
-                                        continue;
-                                    }
-                                    // There's an QEXPECT_FAIL but test passed, not good.
-                                    let xpass = pass && obj["todo"].includes("returned TRUE unexpectedly");
-                                    if (!pass || xpass) {
-                                        // We found a failure
-                                        var name = obj["name"].replace(/\(.*\)/, "");
-                                        var filename = "";
-                                        var lineNumber = -1;
-                                        if (obj["diag"]) {
-                                            filename = obj["diag"]["file"];
-                                            lineNumber = obj["diag"]["line"];
-                                        }
-                                        else {
-                                            // A XPASS for example misses file:line info. Nothing we can do, it's a Qt bug arguably.
-                                        }
-                                        failedResults.push({
-                                            name: name,
-                                            filePath: filename,
-                                            lineNumber: lineNumber,
-                                        });
-                                    }
-                                }
-                                catch (e) { }
-                            }
-                        }
-                        catch (e) { }
-                        resolve(failedResults);
-                    }
-                });
-            });
-            for (let failure of failures) {
-                if (slot && slot.name != failure.name) {
-                    // We executed a single slot, ignore anything else
-                    continue;
-                }
-                let failedSlot = this.slotByName(failure.name);
-                if (failedSlot) {
-                    failedSlot.lastTestFailure = failure;
+    async updateSubTestStates(cwdDir, slot) {
+        let tapFileName = cwdDir + "/" + this.tapOutputFileName(slot);
+        var failures = await new Promise((resolve, reject) => {
+            fs.readFile(tapFileName, "utf8", (error, data) => {
+                if (error) {
+                    logMessage("ERROR: Failed to read log file");
+                    reject(error);
                 }
                 else {
-                    logMessage("ERROR: Failed to find slot with name " + failure.name);
+                    let failedResults = [];
+                    try {
+                        const tap_events = tap_parser_1.Parser.parse(data);
+                        for (let event of tap_events) {
+                            try {
+                                if (event.length < 2)
+                                    continue;
+                                if (event.at(0) != "assert")
+                                    continue;
+                                var obj = event.at(1);
+                                let pass = obj["ok"] === true;
+                                let xfail = !pass && obj["todo"] !== false;
+                                if (xfail) {
+                                    // This is a QEXPECT_FAIL test, all good.
+                                    // QtTest outputs it as "todo"
+                                    continue;
+                                }
+                                // There's an QEXPECT_FAIL but test passed, not good.
+                                let xpass = pass && obj["todo"].includes("returned TRUE unexpectedly");
+                                if (!pass || xpass) {
+                                    // We found a failure
+                                    var name = obj["name"].replace(/\(.*\)/, "");
+                                    var filename = "";
+                                    var lineNumber = -1;
+                                    if (obj["diag"]) {
+                                        filename = obj["diag"]["file"];
+                                        lineNumber = obj["diag"]["line"];
+                                    }
+                                    else {
+                                        // A XPASS for example misses file:line info. Nothing we can do, it's a Qt bug arguably.
+                                    }
+                                    failedResults.push({
+                                        name: name,
+                                        filePath: filename,
+                                        lineNumber: lineNumber,
+                                    });
+                                }
+                            }
+                            catch (e) { }
+                        }
+                    }
+                    catch (e) { }
+                    resolve(failedResults);
                 }
-            }
+            });
         });
+        for (let failure of failures) {
+            if (slot && slot.name != failure.name) {
+                // We executed a single slot, ignore anything else
+                continue;
+            }
+            let failedSlot = this.slotByName(failure.name);
+            if (failedSlot) {
+                failedSlot.lastTestFailure = failure;
+            }
+            else {
+                logMessage("ERROR: Failed to find slot with name " + failure.name);
+            }
+        }
     }
 }
 exports.QtTest = QtTest;
@@ -370,6 +357,13 @@ exports.QtTest = QtTest;
  * Represents a single Qt test slot
  */
 class QtTestSlot {
+    name;
+    // The QTest executable this slot belongs to
+    parentQTest;
+    /// Allows vscode extensions to associate with a test item
+    vscodeTestItem;
+    /// Set after running
+    lastTestFailure;
     constructor(name, parent) {
         this.name = name;
         this.parentQTest = parent;
@@ -380,10 +374,8 @@ class QtTestSlot {
     get absoluteFilePath() {
         return this.parentQTest.filename;
     }
-    runTest() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this.parentQTest.runTest(this);
-        });
+    async runTest() {
+        return this.parentQTest.runTest(this);
     }
     command() {
         return {
@@ -398,51 +390,43 @@ exports.QtTestSlot = QtTestSlot;
  * Represents the list of all QtTest executables in your project
  */
 class QtTests {
-    constructor() {
-        this.qtTestExecutables = [];
-    }
-    discoverViaCMake(buildDirPath) {
-        return __awaiter(this, void 0, void 0, function* () {
-            var cmake = new cmake_1.CMakeTests(buildDirPath);
-            let ctests = yield cmake.tests();
-            if (ctests) {
-                for (let ctest of ctests) {
-                    let qtest = new QtTest(ctest.executablePath(), buildDirPath);
-                    this.qtTestExecutables.push(qtest);
-                }
+    qtTestExecutables = [];
+    async discoverViaCMake(buildDirPath) {
+        var cmake = new cmake_1.CMakeTests(buildDirPath);
+        let ctests = await cmake.tests();
+        if (ctests) {
+            for (let ctest of ctests) {
+                let qtest = new QtTest(ctest.executablePath(), buildDirPath);
+                this.qtTestExecutables.push(qtest);
             }
-            else {
-                logMessage("ERROR: Failed to retrieve ctests!");
-            }
-        });
+        }
+        else {
+            logMessage("ERROR: Failed to retrieve ctests!");
+        }
     }
     /// Removes any executable (from the list) that doesn't link to libQtTest.so
     /// This heuristic tries to filter-out doctest and other non-Qt tests
     /// Only implemented for linux for now
-    removeNonLinking() {
-        return __awaiter(this, void 0, void 0, function* () {
-            let isLinux = process.platform === "linux";
-            if (!isLinux) {
-                return;
+    async removeNonLinking() {
+        let isLinux = process.platform === "linux";
+        if (!isLinux) {
+            return;
+        }
+        let acceptedExecutables = [];
+        for (let ex of this.qtTestExecutables) {
+            let linksToQt = await ex.linksToQtTestLib();
+            // undefined or true is accepted
+            if (linksToQt !== false) {
+                acceptedExecutables.push(ex);
             }
-            let acceptedExecutables = [];
-            for (let ex of this.qtTestExecutables) {
-                let linksToQt = yield ex.linksToQtTestLib();
-                // undefined or true is accepted
-                if (linksToQt !== false) {
-                    acceptedExecutables.push(ex);
-                }
-                this.qtTestExecutables = acceptedExecutables;
-            }
-        });
+            this.qtTestExecutables = acceptedExecutables;
+        }
     }
     setLogFunction(func) {
         gLogFunction = func;
     }
-    removeByRunningHelp() {
-        return __awaiter(this, void 0, void 0, function* () {
-            this.qtTestExecutables = this.qtTestExecutables.filter((ex) => __awaiter(this, void 0, void 0, function* () { return yield ex.isQtTestViaHelp(); }));
-        });
+    async removeByRunningHelp() {
+        this.qtTestExecutables = this.qtTestExecutables.filter(async (ex) => await ex.isQtTestViaHelp());
     }
     /// Removes any executable (from the list) that matches the specified regex
     removeMatching(regex) {
@@ -457,19 +441,17 @@ class QtTests {
             console.log(ex.filename);
         }
     }
-    dumpTestSlots() {
-        return __awaiter(this, void 0, void 0, function* () {
-            for (var ex of this.qtTestExecutables) {
-                if (!ex.slots)
-                    yield ex.parseAvailableSlots();
-                console.log(ex.filename);
-                if (ex.slots) {
-                    for (let slot of ex.slots) {
-                        console.log("    - " + slot.name);
-                    }
+    async dumpTestSlots() {
+        for (var ex of this.qtTestExecutables) {
+            if (!ex.slots)
+                await ex.parseAvailableSlots();
+            console.log(ex.filename);
+            if (ex.slots) {
+                for (let slot of ex.slots) {
+                    console.log("    - " + slot.name);
                 }
             }
-        });
+        }
     }
     /// Returns all executables that contain a Qt test slot with the specified name
     executablesContainingSlot(slotName) {

--- a/out/test.js
+++ b/out/test.js
@@ -2,244 +2,229 @@
 // SPDX-FileCopyrightText: 2024 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 // Author: Sergio Martins <sergio.martins@kdab.com>
 // SPDX-License-Identifier: MIT
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 const cmake_1 = require("./cmake");
 const qttest_1 = require("./qttest");
 // Be sure to build the Qt tests with CMake first
 // See .github/workflows/ci.yml
-function runTests(buildDirPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-        let qt = new qttest_1.QtTests();
-        yield qt.discoverViaCMake(buildDirPath);
-        let expected_executables = [
-            "test/qt_test/build-dev/test1",
-            "test/qt_test/build-dev/test2",
-            "test/qt_test/build-dev/test3",
-            "test/qt_test/build-dev/non_qttest",
-        ];
-        if (qt.qtTestExecutables.length != expected_executables.length) {
-            console.error("Expected 3 executables, got " + qt.qtTestExecutables.length);
+async function runTests(buildDirPath) {
+    let qt = new qttest_1.QtTests();
+    await qt.discoverViaCMake(buildDirPath);
+    let expected_executables = [
+        "test/qt_test/build-dev/test1",
+        "test/qt_test/build-dev/test2",
+        "test/qt_test/build-dev/test3",
+        "test/qt_test/build-dev/non_qttest",
+    ];
+    if (qt.qtTestExecutables.length != expected_executables.length) {
+        console.error("Expected 3 executables, got " + qt.qtTestExecutables.length);
+        process.exit(1);
+    }
+    await qt.removeNonLinking();
+    /// On macOS and Windows we don't have ldd or equivalent, so we can't check if the test links to QtTest
+    /// Use the help way instead
+    await qt.removeByRunningHelp();
+    /// Remove the non-qttest executable from qt.qtTestExecutables
+    qt.qtTestExecutables = qt.qtTestExecutables.filter((e) => !e.filenameWithoutExtension().endsWith("non_qttest"));
+    if (qt.qtTestExecutables.length != 3) {
+        console.error("Expected 3 executables, at this point got " +
+            qt.qtTestExecutables.length);
+        process.exit(1);
+    }
+    // 1. Test that the executable test names are correct:
+    var i = 0;
+    for (var executable of qt.qtTestExecutables) {
+        let expected = expected_executables[i];
+        if (executable.relativeFilename() != expected) {
+            console.error("Expected executable " +
+                expected +
+                ", got " +
+                executable.relativeFilename());
             process.exit(1);
         }
-        yield qt.removeNonLinking();
-        /// On macOS and Windows we don't have ldd or equivalent, so we can't check if the test links to QtTest
-        /// Use the help way instead
-        yield qt.removeByRunningHelp();
-        /// Remove the non-qttest executable from qt.qtTestExecutables
-        qt.qtTestExecutables = qt.qtTestExecutables.filter((e) => !e.filenameWithoutExtension().endsWith("non_qttest"));
-        if (qt.qtTestExecutables.length != 3) {
-            console.error("Expected 3 executables, at this point got " +
-                qt.qtTestExecutables.length);
-            process.exit(1);
-        }
-        // 1. Test that the executable test names are correct:
+        i++;
+    }
+    // 2. Test that the discovered slots are correct:
+    await qt.dumpTestSlots();
+    let expected_slots = {
+        "test/qt_test/build-dev/test1": ["testA", "testB", "testC", "testXFAIL"],
+        "test/qt_test/build-dev/test2": [
+            "testD",
+            "testE",
+            "testF",
+            "testXPASS",
+            "testMixXFAILWithFAIL",
+        ],
+        "test/qt_test/build-dev/test3": ["testAbortsEverythig", "testH", "testI"],
+    };
+    for (var executable of qt.qtTestExecutables) {
         var i = 0;
-        for (var executable of qt.qtTestExecutables) {
-            let expected = expected_executables[i];
-            if (executable.relativeFilename() != expected) {
-                console.error("Expected executable " +
-                    expected +
-                    ", got " +
-                    executable.relativeFilename());
+        for (let slot of executable.slots) {
+            let expected_slot = expected_slots[executable.relativeFilename()][i];
+            if (slot.name != expected_slot) {
+                console.error("Expected slot " + expected_slot + ", got " + slot.name);
                 process.exit(1);
             }
             i++;
         }
-        // 2. Test that the discovered slots are correct:
-        yield qt.dumpTestSlots();
-        let expected_slots = {
-            "test/qt_test/build-dev/test1": ["testA", "testB", "testC", "testXFAIL"],
-            "test/qt_test/build-dev/test2": [
-                "testD",
-                "testE",
-                "testF",
-                "testXPASS",
-                "testMixXFAILWithFAIL",
-            ],
-            "test/qt_test/build-dev/test3": ["testAbortsEverythig", "testH", "testI"],
-        };
-        for (var executable of qt.qtTestExecutables) {
-            var i = 0;
-            for (let slot of executable.slots) {
-                let expected_slot = expected_slots[executable.relativeFilename()][i];
-                if (slot.name != expected_slot) {
-                    console.error("Expected slot " + expected_slot + ", got " + slot.name);
-                    process.exit(1);
-                }
-                i++;
-            }
+    }
+    // 3. Run the tests:
+    let expected_success = [true, false, false];
+    var i = 0;
+    for (var executable of qt.qtTestExecutables) {
+        await executable.runTest();
+        let wasSuccess = executable.lastExitCode === 0;
+        if (wasSuccess && !expected_success[i]) {
+            console.error("Expected test to fail: " + executable.filename);
+            process.exit(1);
         }
-        // 3. Run the tests:
-        let expected_success = [true, false, false];
-        var i = 0;
-        for (var executable of qt.qtTestExecutables) {
-            yield executable.runTest();
-            let wasSuccess = executable.lastExitCode === 0;
-            if (wasSuccess && !expected_success[i]) {
-                console.error("Expected test to fail: " + executable.filename);
+        else if (!wasSuccess && expected_success[i]) {
+            console.error("Expected test to pass: " + executable.filename);
+            process.exit(1);
+        }
+        if (process.platform === "linux") {
+            if (!executable.linksToQtTestLib()) {
+                console.error("Expected test to link to QtTest: " + executable.filename);
                 process.exit(1);
             }
-            else if (!wasSuccess && expected_success[i]) {
-                console.error("Expected test to pass: " + executable.filename);
-                process.exit(1);
-            }
-            if (process.platform === "linux") {
-                if (!executable.linksToQtTestLib()) {
-                    console.error("Expected test to link to QtTest: " + executable.filename);
-                    process.exit(1);
-                }
-            }
-            i++;
         }
-        // 4. Run individual slots:
-        let slot = qt.qtTestExecutables[0].slots[0];
-        yield slot.runTest();
-        if (slot.lastTestFailure) {
-            console.error("Expected test to pass: " + slot.name);
-            process.exit(1);
-        }
-        let slot2 = qt.qtTestExecutables[1].slots[2];
-        yield slot2.runTest();
-        if (!slot2.lastTestFailure) {
-            console.error("Expected test to fail: " + slot2.name);
-            process.exit(1);
-        }
-        // 5. Test executablesContainingSlot
-        let executables = qt.executablesContainingSlot("testB");
-        if (executables.length != 1) {
-            console.error("Expected 1 executable, got " + executables.length);
-            process.exit(1);
-        }
-        if (!executables[0].filenameWithoutExtension().endsWith("test1")) {
-            console.error("Expected filename to end with test1");
-            process.exit(1);
-        }
-        executables = qt.executablesContainingSlot("non_existing");
-        if (executables.length != 0) {
-            console.error("Expected 0 executables, got " + executables.length);
-            process.exit(1);
-        }
-        // 6. Run a slot that has XFAIL
-        slot = qt.qtTestExecutables[0].slots[3];
-        if (slot.name != "testXFAIL") {
-            console.error("Expected slot name to be testXFAIL");
-            process.exit(1);
-        }
-        yield slot.runTest();
-        if (slot.lastTestFailure) {
-            console.error("Expected test to pass: " + slot.name);
-            process.exit(1);
-        }
-        // 7. Run a slot that has XPASS
-        slot = qt.qtTestExecutables[1].slots[3];
-        if (slot.name != "testXPASS") {
-            console.error("Expected slot name to be testXPASS");
-            process.exit(1);
-        }
-        yield slot.runTest();
-        if (!slot.lastTestFailure) {
-            console.error("Expected test to fail: " + slot.name);
-            process.exit(1);
-        }
-        // 8. Run a slot that has both XFAIL and FAIL
-        slot = qt.qtTestExecutables[1].slots[4];
-        if (slot.name != "testMixXFAILWithFAIL") {
-            console.error("Expected slot name to be testMixXFAILWithFAIL");
-            process.exit(1);
-        }
-        yield slot.runTest();
-        if (!slot.lastTestFailure) {
-            console.error("Expected test to fail: " + slot.name);
-            process.exit(1);
-        }
-    });
+        i++;
+    }
+    // 4. Run individual slots:
+    let slot = qt.qtTestExecutables[0].slots[0];
+    await slot.runTest();
+    if (slot.lastTestFailure) {
+        console.error("Expected test to pass: " + slot.name);
+        process.exit(1);
+    }
+    let slot2 = qt.qtTestExecutables[1].slots[2];
+    await slot2.runTest();
+    if (!slot2.lastTestFailure) {
+        console.error("Expected test to fail: " + slot2.name);
+        process.exit(1);
+    }
+    // 5. Test executablesContainingSlot
+    let executables = qt.executablesContainingSlot("testB");
+    if (executables.length != 1) {
+        console.error("Expected 1 executable, got " + executables.length);
+        process.exit(1);
+    }
+    if (!executables[0].filenameWithoutExtension().endsWith("test1")) {
+        console.error("Expected filename to end with test1");
+        process.exit(1);
+    }
+    executables = qt.executablesContainingSlot("non_existing");
+    if (executables.length != 0) {
+        console.error("Expected 0 executables, got " + executables.length);
+        process.exit(1);
+    }
+    // 6. Run a slot that has XFAIL
+    slot = qt.qtTestExecutables[0].slots[3];
+    if (slot.name != "testXFAIL") {
+        console.error("Expected slot name to be testXFAIL");
+        process.exit(1);
+    }
+    await slot.runTest();
+    if (slot.lastTestFailure) {
+        console.error("Expected test to pass: " + slot.name);
+        process.exit(1);
+    }
+    // 7. Run a slot that has XPASS
+    slot = qt.qtTestExecutables[1].slots[3];
+    if (slot.name != "testXPASS") {
+        console.error("Expected slot name to be testXPASS");
+        process.exit(1);
+    }
+    await slot.runTest();
+    if (!slot.lastTestFailure) {
+        console.error("Expected test to fail: " + slot.name);
+        process.exit(1);
+    }
+    // 8. Run a slot that has both XFAIL and FAIL
+    slot = qt.qtTestExecutables[1].slots[4];
+    if (slot.name != "testMixXFAILWithFAIL") {
+        console.error("Expected slot name to be testMixXFAILWithFAIL");
+        process.exit(1);
+    }
+    await slot.runTest();
+    if (!slot.lastTestFailure) {
+        console.error("Expected test to fail: " + slot.name);
+        process.exit(1);
+    }
 }
-function runCodeModelTests(codeModelFile) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const fs = require("fs");
-        let codemodelStr = fs.readFileSync(codeModelFile, "utf8");
-        let codemodelJson = JSON.parse(codemodelStr);
-        let cmake = new cmake_1.CMakeTests("random");
-        let files = cmake.cppFilesForExecutable("/vscode-qttest/test/qt_test/build-dev/test1", codemodelJson);
-        if (files.length != 1) {
-            console.error("Expected 1 file, got " + files.length);
-            process.exit(1);
-        }
-        let expected = "/vscode-qttest/test/qt_test/test1.cpp";
-        let got = files[0].replace(/\\/g, "/");
-        if (got != expected) {
-            console.error("Expected " + expected + ", got " + got);
-            process.exit(1);
-        }
-        let targetName = cmake.targetNameForExecutable("/vscode-qttest/test/qt_test/build-dev/test1", codemodelJson);
-        if (targetName != "test1") {
-            console.error("Expected test1, got " + targetName);
-            process.exit(1);
-        }
-        // test windows back slashes:
-        files = cmake.cppFilesForExecutable("/vscode-qttest/test/qt_test/build-dev/test2", codemodelJson);
-        if (files.length != 1) {
-            console.error("Expected 1 file, got " + files.length);
-            process.exit(1);
-        }
-        targetName = cmake.targetNameForExecutable("/vscode-qttest/test/qt_test/build-dev/test2", codemodelJson);
-        if (targetName != "test2") {
-            console.error("Expected test2, got " + targetName);
-            process.exit(1);
-        }
-        // test workaround for microsoft/vscode-cmake-tools-api/issues/7
-        files = cmake.cppFilesForExecutable("/vscode-qttest/test/qt_test/build-dev/test3", codemodelJson, 
-        /*workaround=*/ false);
-        if (files.length !== 0) {
-            console.error("Expected 0 files, got " + files.length);
-            process.exit(1);
-        }
-        files = cmake.cppFilesForExecutable("/vscode-qttest/test/qt_test/build-dev/test3", codemodelJson, 
-        /*workaround=*/ true);
-        if (files.length !== 1) {
-            console.error("Expected 0 files, got " + files.length);
-            process.exit(1);
-        }
-        targetName = cmake.targetNameForExecutable("/vscode-qttest/test/qt_test/build-dev/test3", codemodelJson, 
-        /*workaround=*/ false);
-        if (targetName) {
-            console.error("Expected null, got " + targetName);
-            process.exit(1);
-        }
-        targetName = cmake.targetNameForExecutable("/vscode-qttest/test/qt_test/build-dev/test3", codemodelJson, 
-        /*workaround=*/ true);
-        if (targetName != "test3") {
-            console.error("Expected null, got " + targetName);
-            process.exit(1);
-        }
-    });
+async function runCodeModelTests(codeModelFile) {
+    const fs = require("fs");
+    let codemodelStr = fs.readFileSync(codeModelFile, "utf8");
+    let codemodelJson = JSON.parse(codemodelStr);
+    let cmake = new cmake_1.CMakeTests("random");
+    let files = cmake.cppFilesForExecutable("/vscode-qttest/test/qt_test/build-dev/test1", codemodelJson);
+    if (files.length != 1) {
+        console.error("Expected 1 file, got " + files.length);
+        process.exit(1);
+    }
+    let expected = "/vscode-qttest/test/qt_test/test1.cpp";
+    let got = files[0].replace(/\\/g, "/");
+    if (got != expected) {
+        console.error("Expected " + expected + ", got " + got);
+        process.exit(1);
+    }
+    let targetName = cmake.targetNameForExecutable("/vscode-qttest/test/qt_test/build-dev/test1", codemodelJson);
+    if (targetName != "test1") {
+        console.error("Expected test1, got " + targetName);
+        process.exit(1);
+    }
+    // test windows back slashes:
+    files = cmake.cppFilesForExecutable("/vscode-qttest/test/qt_test/build-dev/test2", codemodelJson);
+    if (files.length != 1) {
+        console.error("Expected 1 file, got " + files.length);
+        process.exit(1);
+    }
+    targetName = cmake.targetNameForExecutable("/vscode-qttest/test/qt_test/build-dev/test2", codemodelJson);
+    if (targetName != "test2") {
+        console.error("Expected test2, got " + targetName);
+        process.exit(1);
+    }
+    // test workaround for microsoft/vscode-cmake-tools-api/issues/7
+    files = cmake.cppFilesForExecutable("/vscode-qttest/test/qt_test/build-dev/test3", codemodelJson, 
+    /*workaround=*/ false);
+    if (files.length !== 0) {
+        console.error("Expected 0 files, got " + files.length);
+        process.exit(1);
+    }
+    files = cmake.cppFilesForExecutable("/vscode-qttest/test/qt_test/build-dev/test3", codemodelJson, 
+    /*workaround=*/ true);
+    if (files.length !== 1) {
+        console.error("Expected 0 files, got " + files.length);
+        process.exit(1);
+    }
+    targetName = cmake.targetNameForExecutable("/vscode-qttest/test/qt_test/build-dev/test3", codemodelJson, 
+    /*workaround=*/ false);
+    if (targetName) {
+        console.error("Expected null, got " + targetName);
+        process.exit(1);
+    }
+    targetName = cmake.targetNameForExecutable("/vscode-qttest/test/qt_test/build-dev/test3", codemodelJson, 
+    /*workaround=*/ true);
+    if (targetName != "test3") {
+        console.error("Expected null, got " + targetName);
+        process.exit(1);
+    }
 }
-function runNonQtTest(buildDirPath) {
-    return __awaiter(this, void 0, void 0, function* () {
-        let qt = new qttest_1.QtTests();
-        yield qt.discoverViaCMake(buildDirPath);
-        var nonQtExecutable = undefined;
-        for (let executable of qt.qtTestExecutables) {
-            if (executable.filenameWithoutExtension().endsWith("non_qttest")) {
-                nonQtExecutable = executable;
-                break;
-            }
+async function runNonQtTest(buildDirPath) {
+    let qt = new qttest_1.QtTests();
+    await qt.discoverViaCMake(buildDirPath);
+    var nonQtExecutable = undefined;
+    for (let executable of qt.qtTestExecutables) {
+        if (executable.filenameWithoutExtension().endsWith("non_qttest")) {
+            nonQtExecutable = executable;
+            break;
         }
-        if (nonQtExecutable === undefined) {
-            console.error("Expected to find non-Qt test executable");
-            process.exit(1);
-        }
-        yield nonQtExecutable.runTest();
-    });
+    }
+    if (nonQtExecutable === undefined) {
+        console.error("Expected to find non-Qt test executable");
+        process.exit(1);
+    }
+    await nonQtExecutable.runTest();
 }
 runTests("test/qt_test/build-dev/");
 runNonQtTest("test/qt_test/build-dev/");

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   ],
   "author": "sergio.martins@kdab.com",
   "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "devDependencies": {
     "@types/node": "^18.15.0",
     "ts-node": "^10.9.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "CommonJS",
         "esModuleInterop": true,
-        "target": "ES6",
+        "target": "ES2022",
         "outDir": "out",
         "sourceMap": false,
         "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "esModuleInterop": true,
         "target": "ES2022",
         "outDir": "out",
+        "rootDir": "src",
         "sourceMap": false,
         "strict": true,
         "declaration": true


### PR DESCRIPTION
Update TypeScript configuration to target ES2022 and add a root directory to resolve a TypeScript issue. Include an engines field in package.json to specify the minimum Node.js version required. Refresh output files accordingly.