### PR TITLE
feat: propagate CTest ENVIRONMENT to spawned test processes

### DIFF
--- a/src/cmake.ts
+++ b/src/cmake.ts
@@ -75,6 +75,62 @@ export class CMakeTests {
       let test = new CMakeTest();
       test.command = testJSON.command;
       test.cwd = testJSON.cwd;
+
+      // Extract environment information if present in ctest JSON.
+      // ctest may expose environment as `environment` (string or array),
+      // or embed it into `properties` either as an object or array.
+      try {
+        let envArr: string[] | undefined = undefined;
+
+        if (testJSON.environment) {
+          envArr = Array.isArray(testJSON.environment)
+            ? testJSON.environment
+            : [testJSON.environment];
+        }
+
+        if (!envArr && testJSON.properties) {
+          const props = testJSON.properties;
+
+          // properties might be an object with ENVIRONMENT key or an array of {name,value} entries
+          if (!Array.isArray(props) && props.ENVIRONMENT) {
+            const val = props.ENVIRONMENT;
+            if (typeof val === "string") {
+              envArr = [val];
+            } else if (Array.isArray(val)) {
+              envArr = val;
+            }
+          } else if (Array.isArray(props)) {
+            for (const p of props) {
+              if (!p || !p.name) {
+                continue;
+              }
+              if (p.name === "ENVIRONMENT" || p.name === "Environment") {
+                const v = p.value;
+                if (typeof v === "string") {
+                  envArr = [v];
+                } else if (Array.isArray(v)) {
+                  envArr = v;
+                }
+                break;
+              }
+            }
+          }
+        }
+
+        if (envArr) {
+          test.environment = envArr;
+        }
+      } catch (e) {
+        try {
+          logMessage(
+            "ctest: failed to parse environment for test: " +
+              JSON.stringify(testJSON) +
+              " error: " +
+              e,
+          );
+        } catch (_) {}
+      }
+
       return test;
     });
 
@@ -270,6 +326,7 @@ export class CMakeTests {
 export class CMakeTest {
   public command: string[] = [];
   public cwd: string = "";
+  public environment: string[] = [];
 
   public id(): string {
     return this.command.join(",");

--- a/src/qttest.ts
+++ b/src/qttest.ts
@@ -34,6 +34,9 @@ export class QtTest {
   /// The list of individual runnable test slots
   slots: QtTestSlot[] | null = null;
 
+  /// Environment variables coming from CTest (array of "VAR=VALUE")
+  environment: string[] = [];
+
   /// Set after running
   lastExitCode: number = 0;
 
@@ -77,6 +80,19 @@ export class QtTest {
     return result;
   }
 
+  private buildSpawnEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = Object.assign({}, process.env);
+    if (this.environment && Array.isArray(this.environment)) {
+      for (const kv of this.environment) {
+        const idx = kv.indexOf("=");
+        if (idx > -1) {
+          env[kv.substring(0, idx)] = kv.substring(idx + 1);
+        }
+      }
+    }
+    return env;
+  }
+
   /**
    * Calls "./yourqttest -functions" and stores the results in the slots property.
    */
@@ -93,6 +109,7 @@ export class QtTest {
 
       const child = spawn(this.filename, ["-functions"], {
         cwd: this.buildDirPath,
+        env: this.buildSpawnEnv(),
       });
 
       child.stdout.on("data", (chunk) => {
@@ -184,7 +201,9 @@ export class QtTest {
   /// Note that if this is not a QtTest it might not run help and instead execute the test itself
   public async isQtTestViaHelp(): Promise<boolean | undefined> {
     return await new Promise((resolve, reject) => {
-      const child = spawn(this.filename, ["-help"]);
+      const child = spawn(this.filename, ["-help"], {
+        env: this.buildSpawnEnv(),
+      });
       let output = "";
       let result = false;
       child.stdout.on("data", (chunk) => {
@@ -244,7 +263,10 @@ export class QtTest {
           " with cwd=" +
           cwdDir,
       );
-      const child = spawn(this.filename, args, { cwd: cwdDir });
+      const child = spawn(this.filename, args, {
+        cwd: cwdDir,
+        env: this.buildSpawnEnv(),
+      });
 
       if (this.outputFunc) {
         // Callers wants the process output:
@@ -448,6 +470,8 @@ export class QtTests {
     if (ctests) {
       for (let ctest of ctests) {
         let qtest = new QtTest(ctest.executablePath(), buildDirPath);
+        // Propagate environment from CTest metadata
+        qtest.environment = ctest.environment;
         this.qtTestExecutables.push(qtest);
       }
     } else {

--- a/src/test.ts
+++ b/src/test.ts
@@ -12,6 +12,22 @@ async function runTests(buildDirPath: string) {
   let qt = new QtTests();
   await qt.discoverViaCMake(buildDirPath);
 
+  // Verify that environment properties from CTest were discovered for test1
+  const test1Exe = qt.qtTestExecutables.find((e) =>
+    e.filenameWithoutExtension().endsWith("test1"),
+  );
+  if (!test1Exe) {
+    console.error("Expected to find test1 executable after discovery");
+    process.exit(1);
+  }
+  if (!test1Exe.environment || !test1Exe.environment.includes("MY_ENV=VALUE")) {
+    console.error(
+      "Expected test1 to have environment MY_ENV=VALUE, got: " +
+        JSON.stringify(test1Exe.environment),
+    );
+    process.exit(1);
+  }
+
   let expectedExecutables = [
     "test/qt_test/build-dev/test1",
     "test/qt_test/build-dev/test2",

--- a/test/qt_test/CMakeLists.txt
+++ b/test/qt_test/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(test3 Qt${QT_VERSION}::Test)
 
 enable_testing()
 add_test(NAME test1 COMMAND test1)
+set_tests_properties(test1 PROPERTIES ENVIRONMENT "MY_ENV=VALUE")
 add_test(NAME test2 COMMAND test2)
 add_test(NAME test3 COMMAND test3)
 add_test(NAME non_qttest COMMAND non_qttest)

--- a/test/qt_test/test1.cpp
+++ b/test/qt_test/test1.cpp
@@ -12,7 +12,7 @@ private Q_SLOTS:
   void testA() {
     QBENCHMARK { int a = 1; }
   }
-  void testB() {}
+  void testB() { QCOMPARE(qgetenv("MY_ENV"), QByteArray("VALUE")); }
   void testC() { qDebug() << "MyTest::testC()"; }
   void testXFAIL() {
     QEXPECT_FAIL("", "To be fixed", Continue);


### PR DESCRIPTION
- Add `environment` field to `CMakeTest` and extract ENVIRONMENT from ctest JSON (handles `environment` and `properties` shapes).
- Propagate env into `QtTest` and merge/pass it to `spawn()` for -functions, -help and test runs.
- Set `ENVIRONMENT` for `test1` in CMakeLists.txt.
- Add assertion in test1.cpp to verify `MY_ENV=VALUE`.